### PR TITLE
CI: deploy to staging and production

### DIFF
--- a/.github/workflows/build-uberjar.yml
+++ b/.github/workflows/build-uberjar.yml
@@ -1,0 +1,18 @@
+name: Build uberjar
+
+on: [ workflow_call ]
+
+jobs:
+  build-uberjar:
+    name: Build a standalone uberjar
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: |
+          lein deps
+          lein uberjar
+      - uses: actions/upload-artifact@v2
+        with:
+          name: bugle-forms-uberjar
+          path: target/uberjar/bugle-forms-latest-standalone.jar

--- a/.github/workflows/heroku-deploy-production.yml
+++ b/.github/workflows/heroku-deploy-production.yml
@@ -1,0 +1,25 @@
+name: Deploy to production on Heroku
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  call-build-workflow:
+    needs: call-test-workflow
+    uses: ./.github/workflows/build-uberjar.yml
+  deploy-to-staging:
+    runs-on: ubuntu-latest
+    needs: call-build-workflow
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v2
+      with:
+        name: bugle-forms-uberjar
+        path: target/uberjar
+    - uses: akhileshns/heroku-deploy@v3.12.12
+      with:
+        heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
+        heroku_app_name: bugle-forms-production
+        heroku_email: atharva@nilenso.com
+        usedocker: true

--- a/.github/workflows/heroku-deploy-staging.yml
+++ b/.github/workflows/heroku-deploy-staging.yml
@@ -1,0 +1,25 @@
+name: Deploy to staging on Heroku
+
+on: [ push ]
+
+jobs:
+  call-test-workflow:
+    uses: ./.github/workflows/test.yml
+  call-build-workflow:
+    needs: call-test-workflow
+    uses: ./.github/workflows/build-uberjar.yml
+  deploy-to-staging:
+    runs-on: ubuntu-latest
+    needs: call-build-workflow
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v2
+      with:
+        name: bugle-forms-uberjar
+        path: target/uberjar
+    - uses: akhileshns/heroku-deploy@v3.12.12
+      with:
+        heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
+        heroku_app_name: bugle-forms-staging
+        heroku_email: atharva@nilenso.com
+        usedocker: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_call:
 
 jobs:
   run-test:

--- a/src/bugle_forms/core.clj
+++ b/src/bugle_forms/core.clj
@@ -14,7 +14,7 @@
 
 (defn start-server []
   (reset! server (raj/run-jetty hello-world
-                                {:port 8080
+                                {:port (or (Integer. (System/getenv "PORT")) 80)
                                  :join? false})))
 
 (defn stop-server []


### PR DESCRIPTION
Our staged app is now live at: https://bugle-forms-staging.herokuapp.com/

Our production workflow is identical to the staging workflow, but we omit tests, as PRs to master are already tested by the `test.yml` workflow.

Closes: https://app.shortcut.com/nilenso/story/102/setup-ci-pipeline-to-deploy-to-staging-env-in-heroku and https://app.shortcut.com/nilenso/story/103/set-up-ci-pipeline-to-deploy-to-production-env-in-heroku

We'll know if production deployment works once we merge this.