### PR TITLE
ci: fix production deploy workflow

### DIFF
--- a/.github/workflows/heroku-deploy-production.yml
+++ b/.github/workflows/heroku-deploy-production.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   call-build-workflow:
-    needs: call-test-workflow
     uses: ./.github/workflows/build-uberjar.yml
   deploy-to-staging:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Remove erroneous "needs:" line for a job that doesn't exist in this workflow.