### PR TITLE
CI: cache dependencies in job steps

### DIFF
--- a/.github/workflows/build-uberjar.yml
+++ b/.github/workflows/build-uberjar.yml
@@ -8,6 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        env:
+          cache-name: cache-lein-deps
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('project.clj') }}
       - name: Build
         run: |
           lein deps

--- a/.github/workflows/create-dev-artifact.yml
+++ b/.github/workflows/create-dev-artifact.yml
@@ -11,6 +11,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        env:
+          cache-name: cache-lein-deps
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('project.clj') }}
       - name: Build & test
         run: |
           lein deps

--- a/.github/workflows/create-release-artifact.yml
+++ b/.github/workflows/create-release-artifact.yml
@@ -12,6 +12,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        env:
+          cache-name: cache-lein-deps
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('project.clj') }}
       - name: Build & test
         run: |
           lein deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      env:
+        cache-name: cache-lein-deps
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('project.clj') }}
     - name: Install dependencies
       run: lein deps
     - name: Run tests


### PR DESCRIPTION
We use the cache action to avoid repeatedly downloading dependencies for testing, building and artifact release jobs.