### PR TITLE
Setup routes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,8 @@
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [ring/ring-core "1.9.5"]
                  [ring/ring-jetty-adapter "1.9.5"]
-                 [hiccup "1.0.5"]]
+                 [hiccup "1.0.5"]
+                 [bidi "2.1.6"]]
   :main ^:skip-aot bugle-forms.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all

--- a/src/bugle_forms/core.clj
+++ b/src/bugle_forms/core.clj
@@ -1,23 +1,22 @@
 (ns bugle-forms.core
   (:require
-   [bugle-forms.views.layout :as layout]
-   [bugle-forms.views.home :as home]
+   [bidi.ring :refer [make-handler]]
+   [bugle-forms.routes :as r]
    [ring.adapter.jetty :as raj]
-   [ring.middleware.resource :refer [wrap-resource]]
-   [ring.util.response :as response]
-   [hiccup.page :refer [html5]])
+   [ring.middleware.resource :as res])
   (:gen-class))
 
-(defn home [request]
-  (response/response
-   (html5 (layout/application "Bugle Forms" home/content))))
+(def app
+  (-> (make-handler r/routes)
+      (res/wrap-resource "")))
 
 (defonce server (atom nil))
 
 (defn start-server []
-  (reset! server (raj/run-jetty (wrap-resource home "/")
-                                {:port (Integer. (or (System/getenv "PORT") "8080"))
-                                 :join? false})))
+  (reset! server
+          (raj/run-jetty app
+                         {:port (Integer. (or (System/getenv "PORT") "8080"))
+                          :join? false})))
 
 (defn stop-server []
   (when @server (.stop @server))

--- a/src/bugle_forms/handlers/core.clj
+++ b/src/bugle_forms/handlers/core.clj
@@ -1,0 +1,13 @@
+(ns bugle-forms.handlers.core
+  (:require
+   [hiccup.page :refer [html5]]
+   [bugle-forms.views.home :as home-views]
+   [bugle-forms.views.layout :as layout]
+   [ring.util.response :as response]))
+
+(defn home [_]
+  (response/response
+   (html5 (layout/application "Bugle Forms" home-views/content))))
+
+(defn not-found [_]
+  (response/response "404. *sad bugle noises*"))

--- a/src/bugle_forms/handlers/user.clj
+++ b/src/bugle_forms/handlers/user.clj
@@ -2,8 +2,8 @@
   (:require
    [ring.util.response :as response]))
 
-(defn signin [_]
-  (response/response "Stub for sign-in"))
+(defn login [_]
+  (response/response "Stub for log-in"))
 
 (defn signup [_]
   (response/response "Stub for sign-up"))

--- a/src/bugle_forms/handlers/user.clj
+++ b/src/bugle_forms/handlers/user.clj
@@ -1,0 +1,9 @@
+(ns bugle-forms.handlers.user
+  (:require
+   [ring.util.response :as response]))
+
+(defn signin [_]
+  (response/response "Stub for sign-in"))
+
+(defn signup [_]
+  (response/response "Stub for sign-up"))

--- a/src/bugle_forms/routes.clj
+++ b/src/bugle_forms/routes.clj
@@ -7,5 +7,5 @@
   ["/"
    {""       {:get core-handlers/home}
     "signup" {:get user-handlers/signup}
-    "signin" {:get user-handlers/signin}
+    "login" {:get user-handlers/login}
     true     core-handlers/not-found}])

--- a/src/bugle_forms/routes.clj
+++ b/src/bugle_forms/routes.clj
@@ -1,0 +1,11 @@
+(ns bugle-forms.routes
+  (:require
+   [bugle-forms.handlers.core :as core-handlers]
+   [bugle-forms.handlers.user :as user-handlers]))
+
+(def routes
+  ["/"
+   {""       {:get core-handlers/home}
+    "signup" {:get user-handlers/signup}
+    "signin" {:get user-handlers/signin}
+    true     core-handlers/not-found}])

--- a/src/bugle_forms/views/layout.clj
+++ b/src/bugle_forms/views/layout.clj
@@ -18,7 +18,7 @@
          (include-css "/css/main.css")]
         [:body
          [:div {:class "main"}
-          (navbar [["Sign In" "/signin"]
+          (navbar [["Log In" "/login"]
                    ["Sign Up" "/signup"]])
           [:div {:class "content"}
            [:h1 {:class "page-title"} title]


### PR DESCRIPTION
~Currently built on top of (and blocked by) #5. Will rebase if necessary.~

Sets up basic routes for the website. Bidi is the routing library used, mainly because of it's simple, small API and ease of use.

While we are at it, we change the occurrences of the term "Sign In" to "Log In", to prevent slips, as its right next to the "Sign Up" button.

Part of: [sc-110]