### PR TITLE
Implement login and logout

### DIFF
--- a/src/bugle_forms/app.clj
+++ b/src/bugle_forms/app.clj
@@ -3,7 +3,7 @@
    [bugle-forms.config :as config]
    [bugle-forms.middleware :as m]
    [bugle-forms.migrations :as migrate]
-   [bugle-forms.routes :as r]
+   [bugle-forms.handler-dispatch :as dispatch]
    [mount.core :as mount :refer [defstate]]
    [ring.middleware.flash :refer [wrap-flash]]
    [ring.middleware.params :refer [wrap-params]]
@@ -12,7 +12,7 @@
   (:gen-class))
 
 (def app
-  (-> r/route-handler
+  (-> dispatch/route-handler
       m/wrap-keyword-form-params
       wrap-params
       wrap-flash

--- a/src/bugle_forms/handler_dispatch.clj
+++ b/src/bugle_forms/handler_dispatch.clj
@@ -1,0 +1,26 @@
+(ns bugle-forms.handler-dispatch
+  (:require
+   [bidi.ring]
+   [bugle-forms.handlers.utils :as util]
+   [bugle-forms.middleware :as mw]
+   [bugle-forms.routes :as routes]))
+
+(defn handler-from-spec
+  "Parses a handler spec and returns a handler with the specified options."
+  [handler-key]
+  (if (fn? handler-key)
+    ;; If our dispatch object is a function, we assume it to be a
+    ;; ring handler and call it directly.
+    handler-key
+    (let [handler-spec (routes/handler-specs handler-key)
+          {handler       :handler
+           validate-opts :validate
+           access-opts   :access-control} handler-spec]
+      (if handler-spec
+        (cond-> handler
+          validate-opts (mw/validate-request validate-opts)
+          access-opts (mw/wrap-access-control access-opts))
+        util/error-response))))
+
+(def route-handler
+  (bidi.ring/make-handler routes/routes handler-from-spec))

--- a/src/bugle_forms/handlers/user.clj
+++ b/src/bugle_forms/handlers/user.clj
@@ -8,17 +8,21 @@
 
 (defn login
   "Display login form."
-  [{:keys [flash]}]
-  (response/response (layout/application
-                      {:title "Log In" :flash flash}
-                      "Stub for log-in")))
+  [{:keys [flash], {:keys [user]} :session}]
+  (if user
+    (response/redirect "/dashboard" :see-other)
+    (response/response (layout/application
+                        {:title "Log In" :flash flash :user user}
+                        "Stub for log-in"))))
 
 (defn signup
   "Display signup form."
-  [{:keys [flash]}]
-  (response/response (layout/application
-                      {:title "Sign up" :flash flash}
-                      user-views/signup)))
+  [{:keys [flash], {:keys [user]} :session}]
+  (if user
+    (response/redirect "/dashboard" :see-other)
+    (response/response (layout/application
+                        {:title "Sign up" :flash flash}
+                        user-views/signup))))
 
 (defn create-user
   "Create a user from the signup form parameters in a request."
@@ -28,3 +32,12 @@
       (-> (response/redirect "/login" :see-other)
           (assoc :flash "Account creation successful!"))
       (util/flash-redirect "/signup" "User already exists. Try logging in."))))
+
+(defn dashboard
+  "Display a user's dashboard."
+  [{:keys [flash], {:keys [user]} :session}]
+  (if-not user
+    (util/flash-redirect "/login" "Log in to access your dashboard.")
+    (response/response (layout/application
+                        {:title "Dashboard" :flash flash :user user}
+                        "Stub for dashboard"))))

--- a/src/bugle_forms/handlers/user.clj
+++ b/src/bugle_forms/handlers/user.clj
@@ -6,35 +6,29 @@
    [bugle-forms.views.layout :as layout]
    [ring.util.response :as response]))
 
-(defn login
+(defn login-form
   "Display login form."
   [{:keys [flash], {:keys [user]} :session}]
-  (if user
-    (response/redirect "/dashboard" :see-other)
-    (response/response (layout/application
-                        {:title "Log In" :flash flash :user user}
-                        user-views/login))))
+  (response/response (layout/application
+                      {:title "Log In" :flash flash :user user}
+                      user-views/login)))
 
 (defn signup
   "Display signup form."
   [{:keys [flash], {:keys [user]} :session}]
-  (if user
-    (response/redirect "/dashboard" :see-other)
-    (response/response (layout/application
-                        {:title "Sign up" :flash flash}
-                        user-views/signup))))
+  (response/response (layout/application
+                      {:title "Sign up" :flash flash}
+                      user-views/signup)))
 
-(defn create-session
+(defn login
   "Create a session on a successful login."
   [{:keys [form-params session]}]
-  (if (:user session)
-    (response/redirect "/dashboard" :see-other)
-    (let [session-data (user/authenticate form-params)]
-      (if (:error session-data)
-        (util/flash-redirect
-         "/login" "Login failed; Invalid email or password.")
-        (-> (response/redirect "/dashboard" :see-other)
-            (assoc :session (merge session {:user session-data})))))))
+  (let [session-data (user/authenticate form-params)]
+    (if (:error session-data)
+      (util/flash-redirect
+       "/login" "Login failed; Invalid email or password.")
+      (-> (response/redirect "/dashboard" :see-other)
+          (assoc :session (merge session {:user session-data}))))))
 
 (defn create-user
   "Create a user from the signup form parameters in a request."
@@ -48,16 +42,12 @@
 (defn logout
   "Log the user out; deletes session."
   [{{:keys [user]} :session}]
-  (if-not user
-    (response/redirect "/login" :see-other)
-    (-> (util/flash-redirect "/" "Logged out successfully.")
-        (assoc :session nil))))
+  (-> (util/flash-redirect "/" "Logged out successfully.")
+      (assoc :session nil)))
 
 (defn dashboard
   "Display a user's dashboard."
   [{:keys [flash], {:keys [user]} :session}]
-  (if-not user
-    (util/flash-redirect "/login" "Log in to access your dashboard.")
-    (response/response (layout/application
-                        {:title "Dashboard" :flash flash :user user}
-                        (format "Stub for dashboard. Hi, %s!" (:name user))))))
+  (response/response (layout/application
+                      {:title "Dashboard" :flash flash :user user}
+                      (format "Stub for dashboard. Hi, %s!" (:name user)))))

--- a/src/bugle_forms/handlers/user.clj
+++ b/src/bugle_forms/handlers/user.clj
@@ -27,4 +27,4 @@
     (if (user/insert! user)
       (-> (response/redirect "/login" :see-other)
           (assoc :flash "Account creation successful!"))
-      (util/error-redirect "/signup" "User already exists. Try logging in."))))
+      (util/flash-redirect "/signup" "User already exists. Try logging in."))))

--- a/src/bugle_forms/handlers/user.clj
+++ b/src/bugle_forms/handlers/user.clj
@@ -13,7 +13,7 @@
     (response/redirect "/dashboard" :see-other)
     (response/response (layout/application
                         {:title "Log In" :flash flash :user user}
-                        "Stub for log-in"))))
+                        user-views/login))))
 
 (defn signup
   "Display signup form."

--- a/src/bugle_forms/handlers/utils.clj
+++ b/src/bugle_forms/handlers/utils.clj
@@ -7,10 +7,12 @@
 
 (defn home
   "Display home page."
-  [{:keys [flash]}]
-  (response/response (layout/application
-                      {:title "Bugle Forms" :flash flash}
-                      home-views/content)))
+  [{:keys [flash], {:keys [user]} :session}]
+  (if user
+    (response/redirect "/dashboard" :see-other)
+    (response/response (layout/application
+                        {:title "Bugle Forms" :flash flash}
+                        home-views/content))))
 
 (defn not-found
   "Display 404 page."

--- a/src/bugle_forms/handlers/utils.clj
+++ b/src/bugle_forms/handlers/utils.clj
@@ -22,9 +22,8 @@
   [_]
   (response/bad-request "Bad request."))
 
-(defn error-redirect
-  "Redirect to another route with a flash message.
-  Use this to redirect to another page when something goes wrong."
+(defn flash-redirect
+  "Redirect to another route with a flash message."
   [route message]
-  (-> (response/redirect route)
+  (-> (response/redirect route :see-other)
       (assoc :flash message)))

--- a/src/bugle_forms/handlers/utils.clj
+++ b/src/bugle_forms/handlers/utils.clj
@@ -29,3 +29,9 @@
   [route message]
   (-> (response/redirect route :see-other)
       (assoc :flash message)))
+
+(defn error-response
+  "Display 500 internal server error page."
+  [_]
+  (-> (response/response "500 Internal Server Error. *sad bugle noises*")
+      (response/status 500)))

--- a/src/bugle_forms/middleware.clj
+++ b/src/bugle_forms/middleware.clj
@@ -1,5 +1,9 @@
 (ns bugle-forms.middleware
   (:require
+   [bidi.bidi :as bidi]
+   [bugle-forms.routes :as routes]
+   [bugle-forms.handlers.utils :as util-handlers]
+   [clojure.spec.alpha :as s]
    [clojure.stacktrace :as st]
    [clojure.walk :as walk]
    [ring.util.response :as response]))
@@ -24,3 +28,51 @@
     (let [request-kw-form-params (update request :form-params
                                          walk/keywordize-keys)]
       (handler request-kw-form-params))))
+
+(defn validate-request
+  "Guard against malformed requests.
+  Takes an map containing a handler and options to validate the request.
+
+  If the `:spec` option is given, the handler is called only when the `:field`
+  value in the request matches the spec, else a 400 status response is
+  returned."
+  [handler {:keys [spec field]}]
+  (fn [request]
+    (if-not spec
+      (handler request)
+      (if (s/valid? spec (get request field))
+        (handler request)
+        (util-handlers/bad-request request)))))
+
+(defn has-access?
+  "Does this user have access to a resource?"
+  [user-type session-info]
+  (case user-type
+    :member (when session-info true)
+    :guest (when-not session-info true)
+    ;; TODO: Use a logging statement rather than a print.
+    ;; We don't have a logging system in place yet, so this a stopgap.
+    (println "Error: Unknown user-type: " user-type)))
+
+(def access-control-redirects
+  {:member {:route ::routes/login
+            :flash "You need to log in to view this resource."}
+   :guest  {:route ::routes/dashboard}})
+
+(defn resolve-access-redirect
+  [user-type]
+  (let [redirect-info (access-control-redirects user-type)]
+    (assoc redirect-info
+           :path (bidi/path-for routes/routes (:route redirect-info)))))
+
+(defn wrap-access-control
+  "Sets up redirects if a user has no access to the resource in a handler."
+  [handler {user-type :needs}]
+  (fn [{{session-info :user} :session :as request}]
+    (let [{:keys [path flash]} (resolve-access-redirect user-type)
+          redirect (if flash
+                     (partial util-handlers/flash-redirect path flash)
+                     (partial response/redirect path :see-other))]
+      (if-not (has-access? user-type session-info)
+        (redirect)
+        (handler request)))))

--- a/src/bugle_forms/model/user.clj
+++ b/src/bugle_forms/model/user.clj
@@ -43,12 +43,13 @@
   Returns a map containing username and a random session ID if successful, or an
   error value otherwise."
   [{email :email, given-pwd :password}]
-  (if-let [{pwd :password, name :name}
+  (if-let [{pwd :password, name :name, uuid :id}
            (plan/select-one!
-            db/datasource [:name :password]
-            ["select name, password from user_account where email = ?" email])]
+            db/datasource [:id :name :password]
+            ["select id, name, password from user_account where email = ?" email])]
     (if (:valid (hashers/verify given-pwd pwd))
       {:id (generate-session-id)
+       :uuid uuid
        :name name}
       {:error :invalid-password})
     {:error :no-user-found}))

--- a/src/bugle_forms/model/user.clj
+++ b/src/bugle_forms/model/user.clj
@@ -2,7 +2,11 @@
   (:require
    [buddy.hashers :as hashers]
    [bugle-forms.db.connection :as db]
-   [next.jdbc.sql :as sql]))
+   [next.jdbc.sql :as sql]
+   [next.jdbc.plan :as plan])
+  (:import
+   (java.util Base64)
+   (java.security SecureRandom)))
 
 (def user-table :user-account)
 
@@ -24,3 +28,27 @@
   [user]
   (when-not (in-database? user)
     (sql/insert! db/datasource user-table user)))
+
+(defn generate-session-id
+  "Generate a cryptographically secure random session ID."
+  []
+  (let [random (SecureRandom.)
+        base64 (.withoutPadding (Base64/getUrlEncoder))
+        buffer (byte-array 32)]
+    (.nextBytes random buffer)
+    (.encodeToString base64 buffer)))
+
+(defn authenticate
+  "Authenticate user based on provided login credentials.
+  Returns a map containing username and a random session ID if successful, or an
+  error value otherwise."
+  [{email :email, given-pwd :password}]
+  (if-let [{pwd :password, name :name}
+           (plan/select-one!
+            db/datasource [:name :password]
+            ["select name, password from user_account where email = ?" email])]
+    (if (:valid (hashers/verify given-pwd pwd))
+      {:id (generate-session-id)
+       :name name}
+      {:error :invalid-password})
+    {:error :no-user-found}))

--- a/src/bugle_forms/routes.clj
+++ b/src/bugle_forms/routes.clj
@@ -28,7 +28,9 @@
                  :post (validate-request user-handlers/create-user
                                          {:spec ::specs/signup-form
                                           :request-field :form-params})}
-    "login"     {:get user-handlers/login}
+    "login"     {:get user-handlers/login
+                 :post user-handlers/create-session}
+    "logout"    {:get user-handlers/logout}
     "dashboard" {:get user-handlers/dashboard}
     "public"    {:get (br/->Resources {:prefix "public"})}
     true        util-handlers/not-found}])

--- a/src/bugle_forms/routes.clj
+++ b/src/bugle_forms/routes.clj
@@ -1,39 +1,39 @@
 (ns bugle-forms.routes
   (:require
-   [bidi.ring :as br]
+   [bidi.ring]
    [bugle-forms.handlers.user :as user-handlers]
    [bugle-forms.handlers.utils :as util-handlers]
-   [bugle-forms.specs :as specs]
-   [clojure.spec.alpha :as s]))
-
-(defn validate-request
-  "Guard against malformed requests.
-  Takes an map containing a handler and options to validate the request.
-
-  If the `:spec` option is given, the handler is called only when the
-  `:request-field` value in the request matches the spec, else a 400 status
-  response is returned."
-  [handler {:keys [spec request-field]}]
-  (fn [request]
-    (if-not spec
-      (handler request)
-      (if (s/valid? spec (get request request-field))
-        (handler request)
-        (util-handlers/bad-request request)))))
+   [bugle-forms.specs :as specs]))
 
 (def routes
   ["/"
-   {""          {:get util-handlers/home}
-    "signup"    {:get user-handlers/signup
-                 :post (validate-request user-handlers/create-user
-                                         {:spec ::specs/signup-form
-                                          :request-field :form-params})}
-    "login"     {:get user-handlers/login
-                 :post user-handlers/create-session}
-    "logout"    {:get user-handlers/logout}
-    "dashboard" {:get user-handlers/dashboard}
-    "public"    {:get (br/->Resources {:prefix "public"})}
-    true        util-handlers/not-found}])
+   {""          {:get ::home}
+    "signup"    {:get  ::signup
+                 :post ::create-user}
+    "login"     {:get  ::login-form
+                 :post ::login}
+    "logout"    {:get ::logout}
+    "dashboard" {:get ::dashboard}
+    "public"    {:get (bidi.ring/->Resources {:prefix "public"})}
+    true        ::not-found}])
 
-(def route-handler
-  (br/make-handler routes))
+(def handler-specs
+  "Specification of handlers for a matched route.
+  Contains guards for structural validation and access control. Not to be
+  confused with Clojure specs."
+  {::home        {:handler util-handlers/home}
+   ::signup      {:handler user-handlers/signup}
+   ::create-user {:handler user-handlers/create-user
+                  :validate {:spec  ::specs/signup-form
+                             :field :form-params}}
+   ::login-form  {:handler user-handlers/login-form
+                  :access-control {:needs :guest}}
+   ::login       {:handler user-handlers/login
+                  :access-control {:needs :guest}
+                  :validate {:spec  ::specs/login-form
+                             :field :form-params}}
+   ::logout      {:handler  user-handlers/logout
+                  :access-control {:needs :member}}
+   ::dashboard   {:handler user-handlers/dashboard
+                  :access-control {:needs :member}}
+   ::not-found   {:handler util-handlers/not-found}})

--- a/src/bugle_forms/routes.clj
+++ b/src/bugle_forms/routes.clj
@@ -23,14 +23,15 @@
 
 (def routes
   ["/"
-   {""       {:get util-handlers/home}
-    "signup" {:get user-handlers/signup
-              :post (validate-request user-handlers/create-user
-                      {:spec ::specs/signup-form
-                       :request-field :form-params})}
-    "login"  {:get user-handlers/login}
-    "public" {:get (br/->Resources {:prefix "public"})}
-    true     util-handlers/not-found}])
+   {""          {:get util-handlers/home}
+    "signup"    {:get user-handlers/signup
+                 :post (validate-request user-handlers/create-user
+                                         {:spec ::specs/signup-form
+                                          :request-field :form-params})}
+    "login"     {:get user-handlers/login}
+    "dashboard" {:get user-handlers/dashboard}
+    "public"    {:get (br/->Resources {:prefix "public"})}
+    true        util-handlers/not-found}])
 
 (def route-handler
   (br/make-handler routes))

--- a/src/bugle_forms/specs.clj
+++ b/src/bugle_forms/specs.clj
@@ -30,6 +30,10 @@
                    :user/email
                    :user/password]))
 
+(s/def ::login-form
+  (s/keys :req-un [:user/email
+                   :user/password]))
+
 (s/def ::user-account
   (s/keys :req [:user/name
                 :user/email

--- a/src/bugle_forms/views/layout.clj
+++ b/src/bugle_forms/views/layout.clj
@@ -12,9 +12,9 @@
 
 (defn application
   "Returns a representation of the application frontend.
-  Takes a title and a flash message that is displayed to the user when
-  specified."
-  ([{:keys [title flash]} & content]
+  Generates HTML based on a title, a flash message that is displayed to the user
+  when specified, and user information, if they are logged in."
+  ([{:keys [title flash user]} & content]
    (html5 [:head [:title title]
            [:meta {:content "text/html" :charset "utf-8"}]
            [:link {:rel "apple-touch-icon" :type "image/png" :sizes "180x180" :href "/public/apple-touch-icon.png"}]
@@ -24,8 +24,11 @@
            (include-css "/public/css/main.css")]
           [:body
            [:div {:class "main"}
-            (navbar [{:title "Log In", :url "/login"}
-                     {:title "Sign Up", :url "/signup"}])
+            (if user
+              (navbar [{:title "Dashboard" , :url "/dashboard"}
+                       {:title "Log Out" , :url "/logout"}])
+              (navbar [{:title "Log In", :url "/login"}
+                       {:title "Sign Up", :url "/signup"}]))
             [:div {:class "content"}
              (when flash
                [:div {:class "flash-message"} flash])

--- a/src/bugle_forms/views/user.clj
+++ b/src/bugle_forms/views/user.clj
@@ -30,3 +30,24 @@
       :name "password"
       :type "password")]
     [:button {:type "submit" :class "btn btn-primary"} "Sign me up!"]]])
+
+(def login
+  "Representation of the login form."
+  [:div
+   [:form {:action "/login" :method "POST"}
+    [:div {:id "email"}
+     (util/labelled-text-input
+      "Email Address"
+      :required true
+      :pattern "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{1,63}$"
+      :id "email"
+      :name "email"
+      :type "email")]
+    [:div {:id "password"}
+     (util/labelled-text-input
+      "Password"
+      :required true
+      :id "password"
+      :name "password"
+      :type "password")]
+    [:button {:type "submit" :class "btn btn-primary"} "Log In"]]])

--- a/test/bugle_forms/fixtures.clj
+++ b/test/bugle_forms/fixtures.clj
@@ -22,9 +22,10 @@
 (defn setup-db [tests]
   (mount/stop #'db/datasource)
   (mount/start #'db/datasource)
+  (migrations/rollback)
   (migrations/migrate)
   (try (tests)
-    (finally (migrations/rollback)))
+       (finally (migrations/rollback)))
   (mount/stop #'db/datasource))
 
 (defn clear-db [tests]

--- a/test/bugle_forms/handlers/user_test.clj
+++ b/test/bugle_forms/handlers/user_test.clj
@@ -28,5 +28,5 @@
                               :password "t0ps3cr3t"}
           request {:form-params signup-form-params}
           response (sut/create-user request)]
-      (is (= 302 (:status response)))
+      (is (= 303 (:status response)))
       (is (= {"Location" "/signup"} (:headers response))))))

--- a/test/bugle_forms/handlers/user_test.clj
+++ b/test/bugle_forms/handlers/user_test.clj
@@ -30,3 +30,42 @@
           response (sut/create-user request)]
       (is (= 303 (:status response)))
       (is (= {"Location" "/signup"} (:headers response))))))
+
+(deftest logged-in-user-routes
+  (testing "Logged in user is redirected to dashboard from login page"
+    (let [request {:session {:user {:name "Ghanshyam Pinto"
+                                    :id (java.util.UUID/randomUUID)}}}
+          response (sut/login request)]
+      (is (= 303 (:status response)))
+      (is (= {"Location" "/dashboard"} (:headers response)))))
+
+  (testing "Logged in user is redirected to dashboard from signup page"
+    (let [request {:session {:user {:name "Ghanshyam Pinto"
+                                    :id (java.util.UUID/randomUUID)}}}
+          response (sut/signup request)]
+      (is (= 303 (:status response)))
+      (is (= {"Location" "/dashboard"} (:headers response)))))
+
+  (testing "Logged in user can see dashboard"
+    (let [request {:session {:user {:name "Ghanshyam Pinto"
+                                    :id (java.util.UUID/randomUUID)}}}
+          response (sut/dashboard request)]
+      (is (= 200 (:status response)))
+      (is (re-find #"Log Out" (:body response))))))
+
+(deftest logged-out-user-routes
+  (testing "Logged out user can see login page"
+    (let [request {:session nil}
+          response (sut/login request)]
+      (is (= 200 (:status response)))))
+
+  (testing "Logged out user can see signup page"
+    (let [request {:session nil}
+          response (sut/signup request)]
+      (is (= 200 (:status response)))))
+
+  (testing "Logged out user is redirected to login when trying to see dashboard"
+    (let [request {:session nil}
+          response (sut/dashboard request)]
+      (is (= 303 (:status response)))
+      (is (= {"Location" "/login"} (:headers response))))))

--- a/test/bugle_forms/middleware_test.clj
+++ b/test/bugle_forms/middleware_test.clj
@@ -22,3 +22,63 @@
           app                          (m/wrap-keyword-form-params identity)
           response                     (app request-with-str-form-params)]
       (is (every? keyword? (keys (:form-params response)))))))
+
+(deftest validate-request
+  (testing "malformed requests return a 400 Bad Request response"
+    (let [handler (fn [_] {:status 200, :headers {}, :body "Success"})
+          wrapped-handler (m/validate-request handler
+                                              {:spec even?
+                                               :field :params})
+          malformed-request {:request-method :get
+                             :params 3}
+          response (wrapped-handler malformed-request)]
+      (is (= (:status response) 400))))
+
+  (testing "well-formed requests return the handler's response"
+    (let [handler (fn [_] {:status 200, :headers {}, :body "Success"})
+          wrapped-handler (m/validate-request handler
+                                              {:spec even?
+                                               :field :params})
+          request {:request-method :get
+                   :params 2}
+          response (wrapped-handler request)]
+      (is (= (:status response) 200))
+      (is (= (:body response) "Success")))))
+
+(deftest wrap-access-control
+  (testing "Logged in user trying to access a guest resource is redirected to dashboard"
+    (let [handler (fn [_] {:status 200, :headers {}, :body "Log in page"})
+          wrapped-handler (m/wrap-access-control handler {:needs :guest})
+          session-request {:request-method :get
+                           :session {:user {:name "Ghanshyam"
+                                            :id (java.util.UUID/randomUUID)}}}
+          response (wrapped-handler session-request)]
+      (is (= (:status response) 303))
+      (is (= (:headers response) {"Location" "/dashboard"}))))
+
+  (testing "Logged in user has access to a member resource"
+    (let [handler (fn [_] {:status 200, :headers {}, :body "Dashboard"})
+          wrapped-handler (m/wrap-access-control handler {:needs :member})
+          session-request {:request-method :get
+                           :session {:user {:name "Ghanshyam"
+                                            :id (java.util.UUID/randomUUID)}}}
+          response (wrapped-handler session-request)]
+      (is (= (:status response) 200))
+      (is (= (:body response) "Dashboard"))))
+
+  (testing "Logged out user trying to access a member resource is redirected to login"
+    (let [handler (fn [_] {:status 200, :headers {}, :body "Dashboard"})
+          wrapped-handler (m/wrap-access-control handler {:needs :member})
+          session-request {:request-method :get}
+          response (wrapped-handler session-request)]
+      (is (= (:status response) 303))
+      (is (= (:flash response) "You need to log in to view this resource."))
+      (is (= (:headers response) {"Location" "/login"}))))
+
+  (testing "Logged out user has access to a guest resource"
+    (let [handler (fn [_] {:status 200, :headers {}, :body "Log in page"})
+          wrapped-handler (m/wrap-access-control handler {:needs :guest})
+          session-request {:request-method :get}
+          response (wrapped-handler session-request)]
+      (is (= (:status response) 200))
+      (is (= (:body response) "Log in page")))))

--- a/test/bugle_forms/model/user_test.clj
+++ b/test/bugle_forms/model/user_test.clj
@@ -1,10 +1,15 @@
 (ns bugle-forms.model.user-test
   (:require
-   [bugle-forms.specs :as specs]
+   [bugle-forms.fixtures :as fixtures]
    [bugle-forms.model.user :as user]
+   [bugle-forms.specs :as specs]
    [clojure.spec.alpha :as cljspec]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [clojure.test.check.clojure-test :refer [defspec]]
    [clojure.test.check.properties :as prop]))
+
+(use-fixtures :once fixtures/setup-config fixtures/setup-db)
+(use-fixtures :each fixtures/clear-db)
 
 (def run-counts
   {:form-data-test 5})
@@ -15,3 +20,25 @@
    [form-params (cljspec/gen ::specs/signup-form)]
    (cljspec/valid? ::specs/user-account
                    (user/create form-params))))
+
+(deftest authenticate
+  (let [user-data {:name "Ghanshyam Pinto"
+                   :email "gs@nilen.so"
+                   :password "t0ps3cr3t"}
+        a-user (user/create user-data)
+        _ (user/insert! a-user)]
+    (testing "Existing user is assigned a valid session ID"
+      (let [login-params (select-keys user-data [:email :password])
+            auth-response (user/authenticate login-params)]
+        (is (string? (:id auth-response)))
+        (is (= (:name user-data) (:name auth-response)))))
+
+    (testing "Nonexistent user gets an error"
+      (let [login-params {:email "fake@fake.com" :password "t0ps3cr3t"}
+            auth-response (user/authenticate login-params)]
+        (is (= {:error :no-user-found} auth-response))))
+
+    (testing "Wrong password gets an error"
+      (let [login-params {:email (:email user-data) :password "hunter2"}
+            auth-response (user/authenticate login-params)]
+        (is (= {:error :invalid-password} auth-response))))))

--- a/test/bugle_forms/model/user_test.clj
+++ b/test/bugle_forms/model/user_test.clj
@@ -31,6 +31,7 @@
       (let [login-params (select-keys user-data [:email :password])
             auth-response (user/authenticate login-params)]
         (is (string? (:id auth-response)))
+        (is (not-empty (:id auth-response)))
         (is (= (:name user-data) (:name auth-response)))))
 
     (testing "Nonexistent user gets an error"


### PR DESCRIPTION
Closes [sc-135].

We store sessions in memory for the time being. Adding a persistent external store is possible without change to this code by implementing Ring's [SessionStore protocol](https://github.com/ring-clojure/ring/wiki/Sessions#session-stores). This is a task reserved for later (cf. [ADR-001](https://github.com/nilenso/bugle-forms/blob/4cf9e36edc5580edc9159e10b3d0678b671dc28c/doc/arch/adr-001-sessions-for-auth.md)).