### PR TITLE
Allow users to create forms

### DIFF
--- a/resources/migrations/20220316091652-create-form.down.sql
+++ b/resources/migrations/20220316091652-create-form.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS form;

--- a/resources/migrations/20220316091652-create-form.up.sql
+++ b/resources/migrations/20220316091652-create-form.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS form (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name text NOT NULL,
+    owner UUID NOT NULL REFERENCES user_account(id),
+    created TIMESTAMP NOT NULL DEFAULT current_timestamp
+);

--- a/resources/public/css/main.css
+++ b/resources/public/css/main.css
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-@import url('https://fonts.googleapis.com/css2?family=Syne:wght@400;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Syne:wght@400;600;800&display=swap');
 
 body {
     background-color: #FCF7F8;
@@ -120,6 +120,7 @@ label {
 
 .form-control {
     box-shadow: none;
+    box-sizing: border-box;
     font-family: inherit;
     font-size: 1.5em;
     color: #343434 !important;
@@ -144,7 +145,50 @@ textarea {
     width: 100%;
 }
 
-label{
+label {
     color:#000;
     text-transform:camel;
+}
+
+.builder-control {
+    display: flex;
+    align-items: center;
+    column-gap: 1em;
+}
+
+.builder-control div {
+    flex: 1;
+}
+
+.question-input {
+    display: flex;
+    align-items: baseline;
+}
+
+.question-input button {
+    margin-left: 0.3em;
+    margin-top: 0;
+}
+
+.form-list-header {
+    display: flex;
+    font-size: 1.2em;
+    font-weight: 600;
+    margin-bottom: 0.3em;
+    align-items: center;
+}
+
+.form-list-header span {
+    margin-left: auto;
+}
+
+.form-list-item {
+    display: flex;
+    font-size: 1.2em;
+    margin-bottom: 0.3em;
+    align-items: center;
+}
+
+.form-list-item span {
+    margin-left: auto;
 }

--- a/src/bugle_forms/handlers/form.clj
+++ b/src/bugle_forms/handlers/form.clj
@@ -1,0 +1,30 @@
+(ns bugle-forms.handlers.form
+  (:require
+   [bugle-forms.model.form :as form]
+   [bugle-forms.views.form :as form-views]
+   [bugle-forms.views.layout :as layout]
+   [bugle-forms.handlers.utils :as util]
+   [ring.util.response :as response]))
+
+(defn form-builder
+  "Return form builder page."
+  [{{:keys [id]} :route-params
+    {:keys [user]} :session}]
+  (let [{:keys [form/questions form/name error]} (form/get (java.util.UUID/fromString id))]
+    (if error
+      (response/not-found "404. Form not found.")
+      (response/response (layout/application
+                          {:title (str "Editing: " name)
+                           :user user}
+                          (form-views/form-builder
+                           questions))))))
+
+(defn create
+  "Create new form for the user"
+  [{{:keys [user]} :session
+    {:keys [name]} :form-params}]
+  (let [form (form/create name (:uuid user))]
+    (if (form/insert! form)
+      (util/flash-redirect (str "/form-builder/" (:form/id form))
+                           "Form creation successful.")
+      (util/flash-redirect "/dashboard" "Something went wrong."))))

--- a/src/bugle_forms/handlers/user.clj
+++ b/src/bugle_forms/handlers/user.clj
@@ -1,7 +1,9 @@
 (ns bugle-forms.handlers.user
   (:require
    [bugle-forms.handlers.utils :as util]
+   [bugle-forms.model.form :as form]
    [bugle-forms.model.user :as user]
+   [bugle-forms.views.form :as form-views]
    [bugle-forms.views.user :as user-views]
    [bugle-forms.views.layout :as layout]
    [ring.util.response :as response]))
@@ -50,4 +52,7 @@
   [{:keys [flash], {:keys [user]} :session}]
   (response/response (layout/application
                       {:title "Dashboard" :flash flash :user user}
-                      (format "Stub for dashboard. Hi, %s!" (:name user)))))
+                      (list form-views/add-form
+                            [:hr]
+                            (user-views/dashboard-greeting user)
+                            (form-views/list-forms (form/get-forms user))))))

--- a/src/bugle_forms/model/form.clj
+++ b/src/bugle_forms/model/form.clj
@@ -1,0 +1,41 @@
+(ns bugle-forms.model.form
+  (:refer-clojure :exclude [get])
+  (:require
+   [bugle-forms.db.connection :as db]
+   [next.jdbc.plan :as plan]
+   [next.jdbc.sql :as sql]
+   [next.jdbc.date-time])
+  (:import
+   (java.util UUID)
+   (java.time Instant)))
+
+(def form-table :form)
+
+(defn create
+  "Make a form object suitable to be inserted in database.
+  Takes user session data to set the owner of the form."
+  [name user-id]
+  {:form/id (UUID/randomUUID)
+   :form/name name
+   :form/owner user-id
+   :form/created (Instant/now)})
+
+(defn insert!
+  "Insert form in database."
+  [form]
+  (sql/insert! db/datasource form-table form))
+
+(defn get
+  "Retrieve form details."
+  [id]
+  (if-some [form (sql/get-by-id db/datasource form-table id)]
+    form
+    {:error "Form not found."}))
+
+(defn get-forms
+  "Retrieve forms belonging to a user."
+  [{:keys [uuid]}]
+  (plan/select!
+   db/datasource
+   [:id :name :created]
+   ["select id, name, created from form where owner = ? order by created desc" uuid]))

--- a/src/bugle_forms/routes.clj
+++ b/src/bugle_forms/routes.clj
@@ -2,38 +2,48 @@
   (:require
    [bidi.ring]
    [bugle-forms.handlers.user :as user-handlers]
+   [bugle-forms.handlers.form :as form-handlers]
    [bugle-forms.handlers.utils :as util-handlers]
    [bugle-forms.specs :as specs]))
 
 (def routes
   ["/"
-   {""          {:get ::home}
-    "signup"    {:get  ::signup
-                 :post ::create-user}
-    "login"     {:get  ::login-form
-                 :post ::login}
-    "logout"    {:get ::logout}
-    "dashboard" {:get ::dashboard}
-    "public"    {:get (bidi.ring/->Resources {:prefix "public"})}
-    true        ::not-found}])
+   [["" {:get ::home}]
+    ["signup" {:get  ::signup
+               :post ::create-user}]
+    ["login" {:get  ::login-form
+              :post ::login}]
+    ["logout" {:get ::logout}]
+    ["dashboard" {:get ::dashboard}]
+    [["form-builder/" :id] {:get ::form-builder}]
+    ["form" {"" {:post ::create-form}}]
+    ["public" {:get (bidi.ring/->Resources {:prefix "public"})}]
+    [true ::not-found]]])
 
 (def handler-specs
   "Specification of handlers for a matched route.
   Contains guards for structural validation and access control. Not to be
   confused with Clojure specs."
-  {::home        {:handler util-handlers/home}
-   ::signup      {:handler user-handlers/signup}
-   ::create-user {:handler user-handlers/create-user
-                  :validate {:spec  ::specs/signup-form
-                             :field :form-params}}
-   ::login-form  {:handler user-handlers/login-form
-                  :access-control {:needs :guest}}
-   ::login       {:handler user-handlers/login
-                  :access-control {:needs :guest}
-                  :validate {:spec  ::specs/login-form
-                             :field :form-params}}
-   ::logout      {:handler  user-handlers/logout
-                  :access-control {:needs :member}}
-   ::dashboard   {:handler user-handlers/dashboard
-                  :access-control {:needs :member}}
-   ::not-found   {:handler util-handlers/not-found}})
+  {::home         {:handler util-handlers/home}
+   ::signup       {:handler user-handlers/signup
+                   :access-control {:needs :guest}}
+   ::create-user  {:handler user-handlers/create-user
+                   :validate {:spec  ::specs/signup-form
+                              :field :form-params}}
+   ::login-form   {:handler user-handlers/login-form
+                   :access-control {:needs :guest}}
+   ::login        {:handler user-handlers/login
+                   :access-control {:needs :guest}
+                   :validate {:spec  ::specs/login-form
+                              :field :form-params}}
+   ::logout       {:handler user-handlers/logout
+                   :access-control {:needs :member}}
+   ::dashboard    {:handler user-handlers/dashboard
+                   :access-control {:needs :member}}
+   ::create-form  {:handler form-handlers/create
+                   :access-control {:needs :member}
+                   :validate {:spec  ::specs/form-creation-form
+                              :field :form-params}}
+   ::form-builder {:handler form-handlers/form-builder
+                   :access-control {:needs :member}}
+   ::not-found    {:handler util-handlers/not-found}})

--- a/src/bugle_forms/specs.clj
+++ b/src/bugle_forms/specs.clj
@@ -38,3 +38,17 @@
   (s/keys :req [:user/name
                 :user/email
                 :user/password]))
+
+(s/def :form/id uuid?)
+(s/def :form/name (s/and string? seq))
+(s/def :form/owner uuid?)
+(s/def :form/created inst?)
+
+(s/def ::form
+  (s/keys :req [:form/id
+                :form/name
+                :form/owner
+                :form/created]))
+
+(s/def ::form-creation-form
+  (s/keys :req-un [:form/name]))

--- a/src/bugle_forms/views/form.clj
+++ b/src/bugle_forms/views/form.clj
@@ -1,0 +1,56 @@
+(ns bugle-forms.views.form
+  (:require
+   [bugle-forms.views.utils :as util])
+  (:import
+   (java.time ZoneId)
+   (java.time.format DateTimeFormatter)))
+
+(def add-form
+  "Representation for form creation form."
+  [:form {:action "/form" :method :post}
+   [:span {:class "builder-control"}
+    (util/labelled-text-input
+     "Create Form"
+     :id "name"
+     :name "name"
+     :type "text"
+     :placeholder "Enter form name...")
+    [:button {:type "submit" :class "btn"} "→"]]])
+
+(def form->html
+  "TODO: Add form questions"
+  (constantly [:p "Form questions will appear here."]))
+
+(defn formatted-time
+  "Returns a human readable timestamp from a JDBC SQL timestamp."
+  [timestamp]
+  (let [formatter (-> (DateTimeFormatter/ofPattern "dd-MM-yyyy, HH:mm")
+                      (.withZone (ZoneId/of "UTC")))]
+    (.format formatter (.toInstant timestamp))))
+
+(defn list-forms
+  "Show a list of all forms belonging to a user."
+  [forms]
+  (list
+   [:div {:class "form-list-header"} "Form name" [:span "Created on"]]
+   [:hr]
+   (map (fn [form]
+          [:div {:class "form-list-item"}
+           [:a {:href (str "/form-builder/" (:id form))} (:name form)]
+           [:span (formatted-time (:created form))]])
+        forms)))
+
+(defn form-builder
+  "Generate representation of form builder."
+  [form]
+  [:div
+   (form->html form)
+   [:form {:method "post"}
+    [:label {:for "question-input" :class "form-label"}
+     "Enter your question:"]
+    [:input {:class "form-control" :type "text"
+             :name "question-input" :id "question-input"}]
+    [:span {:class "builder-control"}
+     [:button {:formaction "/question" :type "button"
+               :id "add-question" :class "btn"}
+      "+ Add"]]]])

--- a/src/bugle_forms/views/user.clj
+++ b/src/bugle_forms/views/user.clj
@@ -2,6 +2,10 @@
   (:require
    [bugle-forms.views.utils :as util]))
 
+(defn dashboard-greeting
+  [user]
+  (list [:h1 (format "Hi, %s 👋" (:name user))]))
+
 (def signup
   "Representation of the signup form."
   [:div

--- a/test/bugle_forms/factories.clj
+++ b/test/bugle_forms/factories.clj
@@ -1,0 +1,38 @@
+(ns bugle-forms.factories
+  (:require
+   [bugle-forms.specs :as specs]
+   [clojure.spec.alpha :as s]
+   [clojure.spec.gen.alpha :as gen]))
+
+(defn user
+  "Randomly generate a user.
+  Optionally takes a map of overrides."
+  ([] (user {}))
+  ([overrides]
+   (gen/generate
+    (s/gen ::specs/user-account
+           (into {} (map (fn [[k v]]
+                           {k (fn [] (gen/return v))})
+                         overrides))))))
+
+(defn form
+  "Randomly generate a form.
+  Optionally takes a map of overrides."
+  ([] (form {}))
+  ([overrides]
+   (gen/generate
+    (s/gen ::specs/form
+           (into {} (map (fn [[k v]]
+                           {k (fn [] (gen/return v))})
+                         overrides))))))
+
+(defn create-form-params
+  "Randomly generate form params for creating form.
+  Optionally takes a map of overrides."
+  ([] (create-form-params {}))
+  ([overrides]
+   (gen/generate
+    (s/gen ::specs/form-creation-form
+           (into {} (map (fn [[k v]]
+                           {k (fn [] (gen/return v))})
+                         overrides))))))

--- a/test/bugle_forms/handlers/form_test.clj
+++ b/test/bugle_forms/handlers/form_test.clj
@@ -1,0 +1,50 @@
+(ns bugle-forms.handlers.form-test
+  (:require
+   [bugle-forms.db.connection :as db]
+   [bugle-forms.factories :as factories]
+   [bugle-forms.fixtures :as fixtures]
+   [bugle-forms.handlers.form :as sut]
+   [bugle-forms.model.form :as form]
+   [bugle-forms.model.user :as user]
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [next.jdbc.sql :as sql]))
+
+(use-fixtures :once fixtures/setup-config fixtures/setup-db)
+(use-fixtures :each fixtures/clear-db)
+
+(deftest create-form
+  (testing "Form creation handler is successfully creating a form"
+    (let [user (factories/user)
+          {:user-account/keys [id]} (user/insert! user)
+          {form-name :name :as form-params} (factories/create-form-params)
+          request {:form-params form-params
+                   :session {:user {:name (:user/name user)
+                                    :uuid id}}}
+          response (sut/create request)]
+      (is (= 303 (:status response)))
+      (is (.startsWith (get (:headers response) "Location") "/form-builder/"))
+      (is (not-empty (sql/find-by-keys db/datasource :form
+                                       {:name form-name
+                                        :owner id}))))))
+
+(deftest form-builder
+  (testing "Form builder is correctly rendered for a particular form"
+    (let [user (factories/user)
+          {user-id :user-account/id} (user/insert! user)
+          form (factories/form {:form/owner user-id})
+          {form-id :form/id} (form/insert! form)
+          request {:route-params {:id (.toString form-id)}
+                   :session {:user {:name (:user/name user)
+                                    :uuid user-id}}}
+          response (sut/form-builder request)]
+      (is (= 200 (:status response)))))
+
+  (testing "404 when accessing a form that does not exist"
+    (let [user (factories/user)
+          {user-id :user-account/id} (user/insert! user)
+          non-existent-form (factories/form)
+          request {:route-params {:id (str (:form/id non-existent-form))}
+                   :session {:user {:name (:user/name user)
+                                    :uuid user-id}}}
+          response (sut/form-builder request)]
+      (is (= 404 (:status response))))))

--- a/test/bugle_forms/model/form_test.clj
+++ b/test/bugle_forms/model/form_test.clj
@@ -1,0 +1,70 @@
+(ns bugle-forms.model.form-test
+  (:require
+   [bugle-forms.db.connection :as db]
+   [bugle-forms.factories :as factories]
+   [bugle-forms.fixtures :as fixtures]
+   [bugle-forms.model.form :as sut]
+   [bugle-forms.model.user :as user]
+   [bugle-forms.specs :as specs]
+   [clojure.spec.alpha :as s]
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [clojure.test.check.generators :as gen]
+   [next.jdbc.sql :as sql]))
+
+(use-fixtures :once fixtures/setup-config fixtures/setup-db)
+(use-fixtures :each fixtures/clear-db)
+
+(deftest create-form
+  (testing "`create` creates a valid form"
+    (let [name (gen/generate (s/gen :form/name))
+          user-id (gen/generate gen/uuid)
+          form (sut/create name user-id)]
+      (is (s/valid? ::specs/form form))))
+
+  (testing "Form is successfully inserted in database"
+    (let [user (factories/user)
+          {user-id :user-account/id} (user/insert! user)
+          form (factories/form {:form/owner user-id})
+          {:form/keys [id]} (sut/insert! form)]
+      (is (not-empty (sql/get-by-id db/datasource :form id))))))
+
+(deftest get-form-data
+  (testing "We can `get` an inserted form"
+    (let [user (factories/user)
+          {user-id :user-account/id} (user/insert! user)
+          form (factories/form {:form/owner user-id})
+          {:form/keys [id]} (sut/insert! form)]
+      (is (= (sut/get id)
+             (sql/get-by-id db/datasource :form id)))))
+
+  (testing "Cannot `get` a form that does not exist"
+    (let [non-existent-form (factories/form)]
+      (is (:error (sut/get (:form/id non-existent-form))))))
+
+  (testing "All the user's forms are retrieved correctly"
+    (let [user (factories/user)
+          {user-id :user-account/id} (user/insert! user)
+          forms (repeatedly 3 (partial factories/form {:form/owner user-id}))
+          _ (mapv sut/insert! forms)
+          retrieved-forms (sut/get-forms {:uuid user-id})
+          expected (map #(select-keys % [:form/id :form/name :form/created])
+                        (sort-by :form/created #(compare %2 %1) forms))]
+      (is (= (:form/id expected) (:id retrieved-forms)))))
+
+  (testing "`get-forms` for a user that does not exist returns empty collection"
+    (let [uuid (gen/generate gen/uuid)]
+      (is (empty? (sut/get-forms {:uuid uuid})))
+      (is (empty? (sut/get-forms {:uuid nil}))))))
+
+;; This is in a separate `deftest` because our fixtures lead to these tests
+;; happening in a rollback-only transaction. Since this test throws an
+;; exception, it causes subsequent tests to fail because the transaction fails,
+;; and thus none of the other database commands are issued.
+;;
+;; Therefore, any tests throwing a database exception must be in its own
+;; `deftest`
+(deftest create-form-non-existent-user
+  (testing "Cannot insert a form for a non-existent user"
+    (let [form (factories/form)]
+      (is (thrown? org.postgresql.util.PSQLException
+                   (sut/insert! form))))))


### PR DESCRIPTION
Closes [sc-162].

Allow users to create a form from the dashboard. Created forms are displayed on the dashboard.  
Currently, questions cannot be added, and only a non-functional view is displayed.