### PR TITLE
form: prevent user from making bad requests

### DIFF
--- a/src/bugle_forms/views/form.clj
+++ b/src/bugle_forms/views/form.clj
@@ -60,25 +60,29 @@
 (defn form-builder
   "Generate representation of form builder."
   [form-id questions]
-  [:div
-   (list-questions questions)
-   [:form {:method "post"}
-    [:label {:for "text" :class "form-label"}
-     "Enter your question:"]
-    [:span {:class "builder-control" :id "question-input"}
-     [:input {:class "form-control"
-              :type "text"
-              :name "text"
-              :id "text"
-              :required true
-              :pattern ".*\\S+.*"}]
-     [:button {:formaction (str "/form/" form-id "/question")
-               :type "submit"
-               :id "add-question" :class "btn"}
-      "+"]]]
-   [:form {:method "post"}
-    [:span {:class "builder-control"}
-     [:button {:formaction (str "/form/" form-id "/publish")
-               :type "submit"
-               :id "publish-form" :class "btn"}
-      "Publish"]]]])
+  (let [form (form/get form-id)]
+    [:div
+     (list-questions questions)
+     (if-not (form/published? form)
+       (list [:form {:method "post"}
+              [:label {:for "text" :class "form-label"}
+               "Enter your question:"]
+              [:span {:class "builder-control" :id "question-input"}
+               [:input {:class "form-control"
+                        :type "text"
+                        :name "text"
+                        :id "text"
+                        :required true
+                        :pattern ".*\\S+.*"}]
+               [:button {:formaction (str "/form/" form-id "/question")
+                         :type "submit"
+                         :id "add-question" :class "btn"}
+                "+"]]]
+             [:form {:method "post"}
+              [:span {:class "builder-control"}
+               [:button {:formaction (str "/form/" form-id "/publish")
+                         :type "submit"
+                         :id "publish-form" :class "btn"}
+                "Publish"]]])
+       [:span {:class "builder-control"}
+        [:h3 [:a {:href (form/link form)} "[share link]"]]])]))

--- a/src/bugle_forms/views/form.clj
+++ b/src/bugle_forms/views/form.clj
@@ -15,7 +15,9 @@
      :id "name"
      :name "name"
      :type "text"
-     :placeholder "Enter form name...")
+     :placeholder "Enter form name..."
+     :required true
+     :pattern ".*\\S+.*")
     [:button {:type "submit" :class "btn"} "→"]]])
 
 (defn list-questions
@@ -64,12 +66,17 @@
     [:label {:for "text" :class "form-label"}
      "Enter your question:"]
     [:span {:class "builder-control" :id "question-input"}
-     [:input {:class "form-control" :type "text"
-             :name "text" :id "text"}]
+     [:input {:class "form-control"
+              :type "text"
+              :name "text"
+              :id "text"
+              :required true
+              :pattern ".*\\S+.*"}]
      [:button {:formaction (str "/form/" form-id "/question")
                :type "submit"
                :id "add-question" :class "btn"}
-      "+"]]
+      "+"]]]
+   [:form {:method "post"}
     [:span {:class "builder-control"}
      [:button {:formaction (str "/form/" form-id "/publish")
                :type "submit"


### PR DESCRIPTION
We add the required attribute along with a pattern check to disallow whitespace to the input fields for creating a form and adding a question. This prevents a user from making bad requests to the backend and handles the case of blank names gracefully.

We also remove the publish button and "add question" input box and instead present a share link for a published form.

Addresses QA comments on [sc-193].